### PR TITLE
Only call stroke when the whole bezier path has been created. Significan...

### DIFF
--- a/PNChartDemo/PNChart/PNLineChart.m
+++ b/PNChartDemo/PNChart/PNLineChart.m
@@ -135,11 +135,11 @@
             [progressline addLineToPoint:CGPointMake(index * _xLabelWidth  + 30.0+ _xLabelWidth /2.0, chartCavanHeight - grade * chartCavanHeight + 20.0)];
             [progressline moveToPoint:CGPointMake(index * _xLabelWidth + 30.0 + _xLabelWidth /2.0, chartCavanHeight - grade * chartCavanHeight + 20.0 )];
             
-            [progressline stroke];
         }
         
         index += 1;
     }
+    [progressline stroke];
     
     _chartLine.path = progressline.CGPath;
 	if (_strokeColor) {


### PR DESCRIPTION
...t performance fix (charts with 1000 points take < 1 second rather than around 10 seconds)
