### PR TITLE
Added support to define a color per bar.

### DIFF
--- a/PNChartDemo/PCChartsTableViewController.m
+++ b/PNChartDemo/PCChartsTableViewController.m
@@ -108,6 +108,7 @@
         barChart.backgroundColor = [UIColor clearColor];
         [barChart setXLabels:@[@"SEP 1",@"SEP 2",@"SEP 3",@"SEP 4",@"SEP 5",@"SEP 6",@"SEP 7"]];
         [barChart setYValues:@[@1,@24,@12,@18,@30,@10,@21]];
+        [barChart setStrokeColors:@[PNGreen,PNGreen,PNRed,PNGreen,PNGreen,PNYellow,PNGreen]];
         [barChart strokeChart];
         
         [viewController.view addSubview:barChartLabel];

--- a/PNChartDemo/PNChart/PNBarChart.h
+++ b/PNChartDemo/PNChart/PNBarChart.h
@@ -33,6 +33,8 @@
 
 @property (nonatomic, strong) UIColor * strokeColor;
 
+@property (nonatomic, strong) NSArray * strokeColors;
+
 @property (nonatomic, strong) UIColor * barBackgroundColor;
 
 @property (nonatomic) BOOL showLabel;

--- a/PNChartDemo/PNChart/PNBarChart.m
+++ b/PNChartDemo/PNChart/PNBarChart.m
@@ -11,6 +11,10 @@
 #import "PNChartLabel.h"
 #import "PNBar.h"
 
+@interface PNBarChart()
+- (UIColor *)barColorAtIndex:(NSUInteger)index;
+@end
+
 @implementation PNBarChart
 
 - (id)initWithFrame:(CGRect)frame
@@ -97,11 +101,22 @@
             bar = [[PNBar alloc] initWithFrame:CGRectMake((index *  _xLabelWidth + chartMargin + _xLabelWidth * 0.25), self.frame.size.height - chartCavanHeight , _xLabelWidth * 0.6, chartCavanHeight)];
         }
 		bar.backgroundColor = _barBackgroundColor;
-		bar.barColor = _strokeColor;
+		bar.barColor = [self barColorAtIndex:index];
 		bar.grade = grade;
 		[self addSubview:bar];
         
         index += 1;
+    }
+}
+
+#pragma mark - Class extension methods
+
+- (UIColor *)barColorAtIndex:(NSUInteger)index
+{
+    if ([self.strokeColors count] == [self.yValues count]) {
+        return self.strokeColors[index];
+    } else {
+        return self.strokeColor;
     }
 }
 


### PR DESCRIPTION
Implemented the array property „strokeColors“ in order to define a custom color for each bar. If the „strokeColors“ count does not equal the „yValues“ count, the „strokeColor“ is used as the fallback color.
![Barchart with custom bar colors](https://f.cloud.github.com/assets/975938/1797728/1180a3c4-6b06-11e3-8421-b9c4ae11685d.png)
