### PR TITLE
Continuous updating of PNCircleChart

### DIFF
--- a/PNChartDemo/PNChart/PNCircleChart.m
+++ b/PNChartDemo/PNChart/PNCircleChart.m
@@ -9,6 +9,12 @@
 #import "PNCircleChart.h"
 #import "UICountingLabel.h"
 
+@interface PNCircleChart () {
+    UICountingLabel *_gradeLabel;
+}
+
+@end
+
 @implementation PNCircleChart
 
 
@@ -42,6 +48,8 @@
         
         [self.layer addSublayer:_circle];
         [self.layer addSublayer:_circleBG];
+
+		_gradeLabel = [[UICountingLabel alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
         
     }
     
@@ -53,16 +61,15 @@
 {
     //Add count label
     
-    UICountingLabel *gradeLabel = [[UICountingLabel alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
-    [gradeLabel setTextAlignment:NSTextAlignmentCenter];
-    [gradeLabel setFont:[UIFont boldSystemFontOfSize:13.0f]];
-    [gradeLabel setTextColor: PNDeepGrey];
-    [gradeLabel setCenter:CGPointMake(self.center.x,self.center.y)];
-    gradeLabel.method = UILabelCountingMethodEaseInOut;
-    gradeLabel.format = @"%d%%";
+    [_gradeLabel setTextAlignment:NSTextAlignmentCenter];
+    [_gradeLabel setFont:[UIFont boldSystemFontOfSize:13.0f]];
+    [_gradeLabel setTextColor: PNDeepGrey];
+    [_gradeLabel setCenter:CGPointMake(self.center.x,self.center.y)];
+    _gradeLabel.method = UILabelCountingMethodEaseInOut;
+    _gradeLabel.format = @"%d%%";
    
     
-    [self addSubview:gradeLabel];
+    [self addSubview:_gradeLabel];
     
     //Add circle params
     
@@ -80,7 +87,7 @@
     [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
     _circle.strokeEnd   = [_current floatValue]/[_total floatValue];
     
-    [gradeLabel countFrom:0 to:[_current floatValue]/[_total floatValue]*100 withDuration:1.0];
+    [_gradeLabel countFrom:0 to:[_current floatValue]/[_total floatValue]*100 withDuration:1.0];
    
 }
 


### PR DESCRIPTION
In order to update one PNCircleChart which is made previously, gradeLabel has to be private property of PNCircleChart.
In my case, I don't want previous gradeLabel to be kept on the UIView while updating many times.
I wrote this patch for this purpose. Please consider this specification.
