### PR TITLE
Added labelColor property to CircleChart gradeLabel

### DIFF
--- a/PNChartDemo/PNChart/PNCircleChart.h
+++ b/PNChartDemo/PNChart/PNCircleChart.h
@@ -17,7 +17,8 @@
 -(void)strokeChart;
 - (id)initWithFrame:(CGRect)frame andTotal:(NSNumber *)total andCurrent:(NSNumber *)current;
 
-@property (nonatomic, strong) UIColor * strokeColor;
+@property (nonatomic, strong) UIColor *strokeColor;
+@property (nonatomic, strong) UIColor *labelColor;
 @property (nonatomic, strong) NSNumber * total;
 @property (nonatomic, strong) NSNumber * current;
 @property (nonatomic, strong) NSNumber * lineWidth;

--- a/PNChartDemo/PNChart/PNCircleChart.m
+++ b/PNChartDemo/PNChart/PNCircleChart.m
@@ -17,6 +17,14 @@
 
 @implementation PNCircleChart
 
+- (UIColor *)labelColor
+{
+    if (!_labelColor) {
+        _labelColor = PNDeepGrey;
+    }
+    return _labelColor;
+}
+
 
 - (id)initWithFrame:(CGRect)frame andTotal:(NSNumber *)total andCurrent:(NSNumber *)current
 {
@@ -63,7 +71,7 @@
     
     [_gradeLabel setTextAlignment:NSTextAlignmentCenter];
     [_gradeLabel setFont:[UIFont boldSystemFontOfSize:13.0f]];
-    [_gradeLabel setTextColor: PNDeepGrey];
+    [_gradeLabel setTextColor:self.labelColor];
     [_gradeLabel setCenter:CGPointMake(self.center.x,self.center.y)];
     _gradeLabel.method = UILabelCountingMethodEaseInOut;
     _gradeLabel.format = @"%d%%";


### PR DESCRIPTION
Default value is PNDeepGrey, however this didn’t always look nice. So I
added a labelColor property to the CircleChart.

When not set, default is still PNDeepGrey.
