### PR TITLE
Made counting label publicly accessible. Adding ability to grow circle.

### DIFF
--- a/PNChart/PNCircleChart/PNCircleChart.h
+++ b/PNChart/PNCircleChart/PNCircleChart.h
@@ -8,21 +8,29 @@
 
 #import <UIKit/UIKit.h>
 #import "PNColor.h"
+#import "UICountingLabel.h"
 
+typedef NS_ENUM(NSUInteger, PNChartFormatType) {
+  PNChartFormatTypePercent,
+  PNChartFormatTypeDollar,
+  PNChartFormatTypeNone
+};
 
 #define DEGREES_TO_RADIANS(angle) ((angle) / 180.0 * M_PI)
 
 @interface PNCircleChart : UIView
 
 - (void)strokeChart;
+- (void)growChartByAmount:(NSNumber *)growAmount;
 - (id)initWithFrame:(CGRect)frame andTotal:(NSNumber *)total andCurrent:(NSNumber *)current andClockwise:(BOOL)clockwise andShadow:(BOOL)hasBackgroundShadow;
 
+@property (strong, nonatomic) UICountingLabel *countingLabel;
 @property (nonatomic) UIColor *strokeColor;
-@property (nonatomic) UIColor *labelColor;
 @property (nonatomic) NSNumber *total;
 @property (nonatomic) NSNumber *current;
 @property (nonatomic) NSNumber *lineWidth;
-@property (nonatomic) BOOL clockwise;
+@property (nonatomic) NSTimeInterval duration;
+@property (nonatomic) PNChartFormatType chartType;
 
 @property (nonatomic) CAShapeLayer *circle;
 @property (nonatomic) CAShapeLayer *circleBG;

--- a/PNChart/PNCircleChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart/PNCircleChart.m
@@ -7,24 +7,11 @@
 //
 
 #import "PNCircleChart.h"
-#import "UICountingLabel.h"
 
-@interface PNCircleChart () {
-    UICountingLabel *_gradeLabel;
-}
-
+@interface PNCircleChart ()
 @end
 
 @implementation PNCircleChart
-
-- (UIColor *)labelColor
-{
-    if (!_labelColor) {
-        _labelColor = PNDeepGrey;
-    }
-
-    return _labelColor;
-}
 
 
 - (id)initWithFrame:(CGRect)frame andTotal:(NSNumber *)total andCurrent:(NSNumber *)current andClockwise:(BOOL)clockwise andShadow:(BOOL)hasBackgroundShadow
@@ -35,7 +22,8 @@
         _total = total;
         _current = current;
         _strokeColor = PNFreshGreen;
-        _clockwise = clockwise;
+        _duration = 1.0;
+        _chartType = PNChartFormatTypePercent;
 
         CGFloat startAngle = clockwise ? -90.0f : 270.0f;
         CGFloat endAngle = clockwise ? -90.01f : 270.01f;
@@ -62,7 +50,13 @@
         [self.layer addSublayer:_circle];
         [self.layer addSublayer:_circleBG];
 
-        _gradeLabel = [[UICountingLabel alloc] initWithFrame:CGRectMake(0, 0, 50.0, 50.0)];
+        _countingLabel = [[UICountingLabel alloc] initWithFrame:CGRectMake(0, 0, 100.0, 50.0)];
+        [_countingLabel setTextAlignment:NSTextAlignmentCenter];
+        [_countingLabel setFont:[UIFont boldSystemFontOfSize:16.0f]];
+        [_countingLabel setTextColor:[UIColor grayColor]];
+        [_countingLabel setCenter:CGPointMake(self.center.x, self.center.y)];
+        _countingLabel.method = UILabelCountingMethodEaseInOut;
+        [self addSubview:_countingLabel];;
     }
 
     return self;
@@ -71,36 +65,61 @@
 
 - (void)strokeChart
 {
-    //Add count label
+    // Add counting label
+    
+    NSString *format;
+    switch (self.chartType) {
+      case PNChartFormatTypePercent:
+        format = @"%d%%";
+        break;
+      case PNChartFormatTypeDollar:
+        format = @"$%d";
+        break;
+      case PNChartFormatTypeNone:
+      default:
+        format = @"%d";
+        break;
+    }
+    self.countingLabel.format = format;
+    [self addSubview:self.countingLabel];
 
-    [_gradeLabel setTextAlignment:NSTextAlignmentCenter];
-    [_gradeLabel setFont:[UIFont boldSystemFontOfSize:13.0f]];
-    [_gradeLabel setTextColor:self.labelColor];
-    [_gradeLabel setCenter:CGPointMake(self.center.x, self.center.y)];
-    _gradeLabel.method = UILabelCountingMethodEaseInOut;
-    _gradeLabel.format = @"%d%%";
 
-
-    [self addSubview:_gradeLabel];
-
-    //Add circle params
+    // Add circle params
 
     _circle.lineWidth   = [_lineWidth floatValue];
     _circleBG.lineWidth = [_lineWidth floatValue];
     _circleBG.strokeEnd = 1.0;
     _circle.strokeColor = _strokeColor.CGColor;
 
-    //Add Animation
+    // Add Animation
     CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    pathAnimation.duration = 1.0;
+    pathAnimation.duration = self.duration;
     pathAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
     pathAnimation.fromValue = @0.0f;
     pathAnimation.toValue = @([_current floatValue] / [_total floatValue]);
     [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
     _circle.strokeEnd   = [_current floatValue] / [_total floatValue];
 
-    [_gradeLabel countFrom:0 to:[_current floatValue] / [_total floatValue] * 100 withDuration:1.0];
+    [_countingLabel countFrom:0 to:[_current floatValue] withDuration:1.0];
 }
 
+
+
+- (void)growChartByAmount:(NSNumber *)growAmount
+{
+    NSNumber *updatedValue = [NSNumber numberWithFloat:[_current floatValue] + [growAmount floatValue]];
+    
+    // Add animation
+    CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
+    pathAnimation.duration = self.duration;
+    pathAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+    pathAnimation.fromValue = @([_current floatValue] / [_total floatValue]);
+    pathAnimation.toValue = @([updatedValue floatValue] / [_total floatValue]);
+    _circle.strokeEnd   = [updatedValue floatValue] / [_total floatValue];
+    [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
+    
+    [self.countingLabel countFrom:fmin([_current floatValue], [_total floatValue]) to:fmin([_current floatValue] + [growAmount floatValue], [_total floatValue]) withDuration:self.duration];
+    _current = updatedValue;
+}
 
 @end


### PR DESCRIPTION
- Made the entire counting label public, rather than just the label color
- Added an enum to switch formatting between %, $, and none
- Added ability to grow the chart by amount
- Removed clockwise property, since it's not being used after being passed in the initter
- Fixed a problem that prevented the counting label from counting to anything other than 100
