### PR TITLE
get rid of the warning when analysing it

### DIFF
--- a/PNChart/PNPieChart/PNPieChart.m
+++ b/PNChart/PNPieChart/PNPieChart.m
@@ -132,7 +132,7 @@
                                  _outterCircleRadius - distance * cos(rad));
     
     CGRect frame;
-    frame.size = CGSizeMake(100, 80);
+    frame = CGRectMake(0, 0, 100, 80);
     
     UILabel *descriptionLabel = [[UILabel alloc] initWithFrame:frame];
     [descriptionLabel setText:titleText];


### PR DESCRIPTION
PNPieChart.m:137:33: warning: Passed-by-value struct argument contains
uninitialized data (e.g., via the field chain: 'origin.x')
