### PR TITLE
[Fix] : fix label background color bug when before iOS7

### DIFF
--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -143,7 +143,7 @@
     [descriptionLabel setTextAlignment:NSTextAlignmentCenter];
     [descriptionLabel setCenter:center];
     [descriptionLabel setAlpha:0];
-    
+    [descriptionLabel setBackgroundColor:[UIColor clearColor]];
 	
 	return descriptionLabel;
 }


### PR DESCRIPTION
[Fix] : 修复饼状图iOS7之前文本背景颜色导致的问题
