### PR TITLE
Fixed circlePath positioning

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -33,8 +33,8 @@
         CGFloat endAngle = clockwise ? -90.01f : 270.01f;
 
         _lineWidth = @8.0f;
-        UIBezierPath *circlePath = [UIBezierPath bezierPathWithArcCenter:CGPointMake(self.center.x, self.center.y)
-                                                                  radius:self.frame.size.height * 0.5
+        UIBezierPath *circlePath = [UIBezierPath bezierPathWithArcCenter:CGPointMake(self.frame.size.width/2, self.frame.size.height/2)
+                                                                  radius:(self.frame.size.height * 0.5) - [_lineWidth floatValue]
                                                               startAngle:DEGREES_TO_RADIANS(startAngle)
                                                                 endAngle:DEGREES_TO_RADIANS(endAngle)
                                                                clockwise:clockwise];


### PR DESCRIPTION
The path for the circlePath in PNCircleChart is positioned in the center of the view, but it go outside the frame of the view, in case of (x,y) values of view's frame different from (0,0), because self.center is relative and not absolute.
Also the radius must subtract the thickness of the line path.  

Before fix (circleChart frame border in green)
![before](https://cloud.githubusercontent.com/assets/2822656/5297445/2fac60b2-7baf-11e4-9185-bdf25ca18ee6.png)

After fix (circleChart frame border in green)
![after](https://cloud.githubusercontent.com/assets/2822656/5297455/44124a4e-7baf-11e4-9016-56a1229fd0b9.png)
