### PR TITLE
Make delegate methods optional

### DIFF
--- a/PNChart/PNChartDelegate.h
+++ b/PNChart/PNChartDelegate.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol PNChartDelegate <NSObject>
-
+@optional
 /**
  * Callback method that gets invoked when the user taps on the chart line.
  */


### PR DESCRIPTION
They should be optional methods so we can get rid of warning when only using one kind of these chart.
