### PR TITLE
Use duration property in counting label

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -157,7 +157,7 @@ displayCountingLabel:(BOOL)displayCountingLabel
     [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
     _circle.strokeEnd   = [_current floatValue] / [_total floatValue];
 
-    [_countingLabel countFrom:0 to:[_current floatValue] withDuration:1.0];
+    [_countingLabel countFrom:0 to:[_current floatValue] withDuration:self.duration];
 
 
     // Check if user wants to add a gradient from the start color to the bar color


### PR DESCRIPTION
Use duration property in counting label of PNCircleChart in order to have the same duration in both animations (graph and label)