### PR TITLE
Added a method to allow the update of both the current and the total for...

### DIFF
--- a/PNChart/PNCircleChart.h
+++ b/PNChart/PNCircleChart.h
@@ -23,6 +23,7 @@ typedef NS_ENUM (NSUInteger, PNChartFormatType) {
 - (void)strokeChart;
 - (void)growChartByAmount:(NSNumber *)growAmount;
 - (void)updateChartByCurrent:(NSNumber *)current;
+- (void)updateChartByCurrent:(NSNumber *)current byTotal:(NSNumber *)total;
 - (id)initWithFrame:(CGRect)frame
               total:(NSNumber *)total
             current:(NSNumber *)current

--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -206,13 +206,20 @@ displayCountingLabel:(BOOL)displayCountingLabel
 
 
 -(void)updateChartByCurrent:(NSNumber *)current{
+    
+    [self updateChartByCurrent:current
+                       byTotal:_total];
+    
+}
+
+-(void)updateChartByCurrent:(NSNumber *)current byTotal:(NSNumber *)total {
     // Add animation
     CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
     pathAnimation.duration = self.duration;
     pathAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
     pathAnimation.fromValue = @([_current floatValue] / [_total floatValue]);
-    pathAnimation.toValue = @([current floatValue] / [_total floatValue]);
-    _circle.strokeEnd   = [current floatValue] / [_total floatValue];
+    pathAnimation.toValue = @([current floatValue] / [total floatValue]);
+    _circle.strokeEnd   = [current floatValue] / [total floatValue];
     
     if (_strokeColorGradientStart) {
         self.gradientMask.strokeEnd = _circle.strokeEnd;
@@ -221,10 +228,11 @@ displayCountingLabel:(BOOL)displayCountingLabel
     [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
     
     if (_displayCountingLabel) {
-        [self.countingLabel countFrom:fmin([_current floatValue], [_total floatValue]) to:fmin([current floatValue], [_total floatValue]) withDuration:self.duration];
+        [self.countingLabel countFrom:fmin([_current floatValue], [_total floatValue]) to:fmin([current floatValue], [total floatValue]) withDuration:self.duration];
     }
     
     _current = current;
+    _total = total;
 }
 
 @end


### PR DESCRIPTION
Added a method to allow the update of both the current and the total for the circle chart so its display remains overall accurate.

- (void)updateChartByCurrent:(NSNumber *)current byTotal:(NSNumber *)total;

We have a scenario where our app is pulling updated counts for both the "checked in" (our current) and "registered and ready to check in" (our total). Since both values can be updated, the chart would not be correct if the option to update the total was not available. I doubt this is a wide spread issue for most users, but since I made the update, I figured I might as well share for others who might need it.