### PR TITLE
Update PNLineChart.m

### DIFF
--- a/PNChart/PNLineChart.m
+++ b/PNChart/PNLineChart.m
@@ -101,6 +101,20 @@
     }
 }
 
+- (CGFloat)computeEqualWidthForXLabels:(NSArray *)xLabels
+{
+    CGFloat xLabelWidth;
+
+    if (_showLabel) {
+        xLabelWidth = _chartCavanWidth / [xLabels count];
+    } else {
+        xLabelWidth = (self.frame.size.width) / [xLabels count];
+    }
+
+    return xLabelWidth;
+}
+
+
 - (void)setXLabels:(NSArray *)xLabels
 {
     CGFloat xLabelWidth;


### PR DESCRIPTION
Transformation of setXLabels with one parameter (the array) to computeEqualWidthForXLabels so it can actually be usable. I use swift and I wasn't able to add from objective c and use the method. Also it was actually not used anywhere and even tho in the main page tutorial it show and example of using it, it was not defined in here so I am also keeping and defining the original one as well just in case. THen again this original function is declared void but attempts to return the result..