### PR TITLE
Show actual percentage in label

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -157,7 +157,7 @@ displayCountingLabel:(BOOL)displayCountingLabel
     [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
     _circle.strokeEnd   = [_current floatValue] / [_total floatValue];
 
-    [_countingLabel countFrom:0 to:[_current floatValue] withDuration:self.duration];
+    [_countingLabel countFrom:0 to:[_current floatValue]/([_total floatValue]/100.0) withDuration:self.duration];
 
 
     // Check if user wants to add a gradient from the start color to the bar color


### PR DESCRIPTION
The label was showing stuff like 6000% which is not relevant if it says the % or maybe %%%.

Anyway I feel this way it is better for a default use?