### PR TITLE
Avoid labels on Y axis duplicate

### DIFF
--- a/PNChart/PNBarChart.m
+++ b/PNChart/PNBarChart.m
@@ -68,6 +68,10 @@
 {
     _yValues = yValues;
 
+    //make the _yLabelSum value dependant of the distinct values of yValues to avoid duplicates on yAxis
+    int yLabelsDifTotal = [NSSet setWithArray:yValues].count;
+    _yLabelSum = yLabelsDifTotal % 2 == 0 ? yLabelsDifTotal : yLabelsDifTotal + 1;
+
     if (_yMaxValue) {
         _yValueMax = _yMaxValue;
     } else {
@@ -114,7 +118,8 @@
 {
     int max = [[yLabels valueForKeyPath:@"@max.intValue"] intValue];
 
-    _yValueMax = (int)max;
+    //ensure max is even
+    _yValueMax = max % 2 == 0 ? max : max + 1;
 
     if (_yValueMax == 0) {
         _yValueMax = _yMinValue;


### PR DESCRIPTION
Modify on `PNBarChart.m` the `setYValues` method to make the number of labels on Y axis ( `_yLabelSum` ) depends on the number of different Y values, avoiding the  duplicate labels on Y axis when the type of chart is Bar Chart, can be related with issue #59.

Also modify `getYValueMax` and `setYValues` methods to ensure the max value of Y axis ( `_yValueMax` ) and the number of labels on Y axis ( `_yLabelSum`) are even to avoid when the Y labels hasn't decimal values (default value for `_yLabelFormatter`) the axis label position not match with the value