### PR TITLE
PieChart: redraw chart if layout changed

### DIFF
--- a/PNChart.podspec
+++ b/PNChart.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "PNChart"
-  s.version      = "0.8.5"
+  s.version      = "0.8.6"
   s.summary      = "A simple and beautiful chart lib with animation used in Piner for iOS"
 
   s.description  = <<-DESC
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/kevinzhow/PNChart.git", :tag => "0.8.5" }
+  s.source       = { :git => "https://github.com/kevinzhow/PNChart.git", :tag => s.version }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/PNChart/PNPieChart.h
+++ b/PNChart/PNPieChart.h
@@ -44,8 +44,16 @@
 /** Default YES. */
 @property (nonatomic) BOOL shouldHighlightSectorOnTouch;
 
+/** Current outer radius. Override recompute() to change this. **/
+@property (nonatomic) CGFloat outerCircleRadius;
+
+/** Current inner radius. Override recompute() to change this. **/
+@property (nonatomic) CGFloat innerCircleRadius;
+
 @property (nonatomic, weak) id<PNChartDelegate> delegate;
 
 - (void)strokeChart;
+
+- (void)recompute;
 
 @end

--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -15,9 +15,6 @@
 @property (nonatomic) NSArray *items;
 @property (nonatomic) NSArray *endPercentages;
 
-@property (nonatomic) CGFloat outerCircleRadius;
-@property (nonatomic) CGFloat innerCircleRadius;
-
 @property (nonatomic) UIView         *contentView;
 @property (nonatomic) CAShapeLayer   *pieLayer;
 @property (nonatomic) NSMutableArray *descriptionLabels;
@@ -48,9 +45,6 @@
     self = [self initWithFrame:frame];
     if(self){
         _items = [NSArray arrayWithArray:items];
-        _outerCircleRadius  = CGRectGetWidth(self.bounds) / 2;
-        _innerCircleRadius  = CGRectGetWidth(self.bounds) / 6;
-        
         _descriptionTextColor = [UIColor whiteColor];
         _descriptionTextFont  = [UIFont fontWithName:@"Avenir-Medium" size:18.0];
         _descriptionTextShadowColor  = [[UIColor blackColor] colorWithAlphaComponent:0.4];
@@ -86,12 +80,20 @@
     
     _pieLayer = [CAShapeLayer layer];
     [_contentView.layer addSublayer:_pieLayer];
+
+}
+
+/** Override this to change how inner attributes are computed. **/
+- (void)recompute {
+    self.outerCircleRadius = CGRectGetWidth(self.bounds) / 2;
+    self.innerCircleRadius = CGRectGetWidth(self.bounds) / 6;
 }
 
 #pragma mark -
 
 - (void)strokeChart{
     [self loadDefault];
+    [self recompute];
     
     PNPieChartDataItem *currentItem;
     for (int i = 0; i < _items.count; i++) {
@@ -443,4 +445,11 @@
     [squareImageView setFrame:CGRectMake(originX, originY, size, size)];
     return squareImageView;
 }
+
+/* Redraw the chart on autolayout */
+-(void)layoutSubviews {
+    [super layoutSubviews];
+    [self strokeChart];
+}
+
 @end


### PR DESCRIPTION
This is to support autolayout and constraints.

Resize layers for current bounds on layoutSubviews.
For that to work we need to have radiuses recomputed on each draw.

As a bonus you can now orverride `recompute` method to change
inner and outer radiuses. With possibility to change other attributes
in a subclass.