### PR TITLE
Added decimal options for circle chart

### DIFF
--- a/PNChart/PNCircleChart.h
+++ b/PNChart/PNCircleChart.h
@@ -13,7 +13,9 @@
 typedef NS_ENUM (NSUInteger, PNChartFormatType) {
     PNChartFormatTypePercent,
     PNChartFormatTypeDollar,
-    PNChartFormatTypeNone
+    PNChartFormatTypeNone,
+    PNChartFormatTypeDecimal,
+    PNChartFormatTypeDecimalTwoPlaces,
 };
 
 #define DEGREES_TO_RADIANS(angle) ((angle) / 180.0 * M_PI)

--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -131,6 +131,12 @@ displayCountingLabel:(BOOL)displayCountingLabel
             case PNChartFormatTypeDollar:
                 format = @"$%d";
                 break;
+            case PNChartFormatTypeDecimal:
+                format = @"%.1f";
+                break;
+            case PNChartFormatTypeDecimalTwoPlaces:
+                format = @"%.2f";
+                break;
             case PNChartFormatTypeNone:
             default:
                 format = @"%d";


### PR DESCRIPTION
I noticed that this was lacking in this particular chart.