### PR TITLE
Using the Right Shadow Color instead of the Green Color

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -46,7 +46,7 @@
                        current:current
                      clockwise:clockwise
                         shadow:shadow
-                   shadowColor:PNGreen
+                   shadowColor:backgroundShadowColor
           displayCountingLabel:displayCountingLabel
              overrideLineWidth:@8.0f];
     


### PR DESCRIPTION
If we use the following method : 
`- (id)initWithFrame:(CGRect)frame`
`total:(NSNumber *)total`
`current:(NSNumber *)current`
`clockwise:(BOOL)clockwise`
`shadow:(BOOL)hasBackgroundShadow`
`shadowColor:(UIColor *)backgroundShadowColor`
`displayCountingLabel:(BOOL)displayCountingLabel`

The `PNGreen` was always set, regardless the color specified in the `backgroundShadowColor`parameter

Hope it helps :smile: 