### PR TITLE
Show only titles, not values nor percentage

### DIFF
--- a/PNChart/PNPieChart.h
+++ b/PNChart/PNPieChart.h
@@ -65,8 +65,4 @@
 
 - (void)recompute;
 
-<<<<<<< Updated upstream
 @end
-=======
-@end
->>>>>>> Stashed changes

--- a/PNChart/PNPieChart.h
+++ b/PNChart/PNPieChart.h
@@ -32,6 +32,9 @@
 /** Default is 1.0. */
 @property (nonatomic) NSTimeInterval duration;
 
+/** show only tiles, not values or percentage */
+@property (nonatomic) BOOL hideValues;
+
 /** Show only values, this is useful when legend is present */
 @property (nonatomic) BOOL showOnlyValues;
 

--- a/PNChart/PNPieChart.h
+++ b/PNChart/PNPieChart.h
@@ -49,6 +49,9 @@
 
 @property (nonatomic, weak) id<PNChartDelegate> delegate;
 
+/** Multiple selection */
+@property (nonatomic, assign) BOOL enableMultipleSelection;
+
 - (void)strokeChart;
 
 @end

--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -149,7 +149,7 @@
     }
     
     if (self.hideValues)
-        descriptionLabel.text =  titleText;
+        descriptionLabel.text = titleText;
     else if(!titleText || self.showOnlyValues)
         descriptionLabel.text = titleValue;
     else {

--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -57,11 +57,8 @@
         _descriptionTextShadowOffset =  CGSizeMake(0, 1);
         _duration = 1.0;
         _shouldHighlightSectorOnTouch = YES;
-<<<<<<< Updated upstream
-=======
         _enableMultipleSelection = NO;
         _hideValues = NO;
->>>>>>> Stashed changes
         
         [super setupDefaultValues];
         [self loadDefault];

--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -57,6 +57,11 @@
         _descriptionTextShadowOffset =  CGSizeMake(0, 1);
         _duration = 1.0;
         _shouldHighlightSectorOnTouch = YES;
+<<<<<<< Updated upstream
+=======
+        _enableMultipleSelection = NO;
+        _hideValues = NO;
+>>>>>>> Stashed changes
         
         [super setupDefaultValues];
         [self loadDefault];
@@ -130,6 +135,7 @@
     
     UILabel *descriptionLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 100, 80)];
     NSString *titleText = currentDataItem.textDescription;
+    
     NSString *titleValue;
     
     if (self.showAbsoluteValues) {
@@ -137,9 +143,11 @@
     }else{
         titleValue = [NSString stringWithFormat:@"%.0f%%",[self ratioForItemAtIndex:index] * 100];
     }
-    if(!titleText || self.showOnlyValues){
+    
+    if (self.hideValues)
+        descriptionLabel.text =  titleText;
+    else if(!titleText || self.showOnlyValues)
         descriptionLabel.text = titleValue;
-    }
     else {
         NSString* str = [titleValue stringByAppendingString:[NSString stringWithFormat:@"\n%@",titleText]];
         descriptionLabel.text = str ;


### PR DESCRIPTION
Added the behavior to show only title inside the PieChart, not values nor percentage.