### PR TITLE
绘制饼图的Bug

### DIFF
--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -59,8 +59,14 @@
 
 - (void)baseInit{
     _selectedItems = [NSMutableDictionary dictionary];
-    _outerCircleRadius  = CGRectGetWidth(self.bounds) / 2;
-    _innerCircleRadius  = CGRectGetWidth(self.bounds) / 6;
+    //在绘制圆形时,应当考虑矩形的宽和高的大小问题,当宽大于高时,绘制饼图时,会超出整个view的范围,因此建议在此处进行判断
+    
+    CGFloat minimal = (CGRectGetWidth(self.bounds) < CGRectGetHeight(self.bounds)) ? CGRectGetWidth(self.bounds) : CGRectGetHeight(self.bounds);
+    
+    _outerCircleRadius  = minimal / 2;
+    _innerCircleRadius  = minimal / 6;
+//    _outerCircleRadius  = CGRectGetWidth(self.bounds) / 2;
+//    _innerCircleRadius  = CGRectGetWidth(self.bounds) / 6;
     _descriptionTextColor = [UIColor whiteColor];
     _descriptionTextFont  = [UIFont fontWithName:@"Avenir-Medium" size:18.0];
     _descriptionTextShadowColor  = [[UIColor blackColor] colorWithAlphaComponent:0.4];
@@ -100,8 +106,11 @@
 
 /** Override this to change how inner attributes are computed. **/
 - (void)recompute {
-    self.outerCircleRadius = CGRectGetWidth(self.bounds) / 2;
-    self.innerCircleRadius = CGRectGetWidth(self.bounds) / 6;
+    
+    //同理
+    CGFloat minimal = (CGRectGetWidth(self.bounds) < CGRectGetHeight(self.bounds)) ? CGRectGetWidth(self.bounds) : CGRectGetHeight(self.bounds);
+    self.outerCircleRadius = minimal / 2;
+    self.innerCircleRadius = minimal / 6;
 }
 
 #pragma mark -


### PR DESCRIPTION
在绘制圆形时,应当考虑矩形的宽和高的大小问题!
当宽明显大于高时,由于原先的方法任然会使用宽度作为半径
所以绘制饼图时,会明显超出整个view的范围,
因此建议在绘制饼图时,判断宽高的大小,然后取较小的值绘制图形
