### PR TITLE
PNCircleChart中displayCountingLabel设置有时无效

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -253,14 +253,18 @@ displayCountingLabel:(BOOL)displayCountingLabel
         pathAnimation.fromValue = @(0.0f);
         pathAnimation.toValue = @([_current floatValue] / [_total floatValue]);
         [_circle addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
-        [_countingLabel countFrom:0 to:percentageValue withDuration:self.duration];
-        
+        if(_displayCountingLabel)
+        {
+            [_countingLabel countFrom:0 to:percentageValue withDuration:self.duration];
+        }
         if (self.gradientMask && _strokeColorGradientStart) {
             [self.gradientMask addAnimation:pathAnimation forKey:@"strokeEndAnimation"];
         }
     }
     else {
-        [_countingLabel countFrom:percentageValue to:percentageValue withDuration:self.duration];
+        if (_displayCountingLabel) {
+            [_countingLabel countFrom:percentageValue to:percentageValue withDuration:self.duration];
+        }
     }
 }
 


### PR DESCRIPTION
如果不使用- (id)initWithFrame:(CGRect)frame
              total:(NSNumber *)total
            current:(NSNumber *)current
          clockwise:(BOOL)clockwise
             shadow:(BOOL)hasBackgroundShadow
        shadowColor:(UIColor *)backgroundShadowColor
displayCountingLabel:(BOOL)displayCountingLabel;这个函数进行初始化,则显示的时候必须判断_displayCountingLabel的值,因为用户可能在init之后修改_displayCountingLabel的值.