### PR TITLE
Fixes warning about assigning PNPieChart as a CAAnimationDelegate

### DIFF
--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -10,7 +10,7 @@
 //needed for the expected label size
 #import "PNLineChart.h"
 
-@interface PNPieChart()
+@interface PNPieChart()<CAAnimationDelegate>
 
 @property (nonatomic) NSArray *items;
 @property (nonatomic) NSArray *endPercentages;


### PR DESCRIPTION
This small PR fixes this annoying warning: `Assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type 'PNPieChart *const __strong'`