### PR TITLE
Fix bug show legned which textDescription was nil

### DIFF
--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -421,6 +421,9 @@
     NSUInteger rowMaxHeight = 0;
     
     for (PNPieChartDataItem *pdata in self.items) {
+        if (!pdata.textDescription) {
+            break;
+        }
         /* Expected label size*/
         CGSize labelsize = [PNLineChart sizeOfString:pdata.textDescription
                                            withWidth:maxLabelWidth


### PR DESCRIPTION
In my project, i use this chart and want's show filter showing some legend.
I use :
```objc
PNPieChartDataItem *item = [PNPieChartDataItem dataItemWithValue:obj.transactionCount color:obj.tagColor];
```
to show just in PIChart not see some item in legend.