### PR TITLE
Fix percentage and float values for specific values

### DIFF
--- a/PNChart/PNCircleChart.m
+++ b/PNChart/PNCircleChart.m
@@ -244,7 +244,7 @@ displayCountingLabel:(BOOL)displayCountingLabel
 
 - (void)addAnimationIfNeeded
 {
-    double percentageValue = [_current floatValue]/([_total floatValue]/100.0);
+    double percentageValue = (_current.floatValue / _total.floatValue) * 100.0f;
     
     if (self.displayAnimated) {
         CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];


### PR DESCRIPTION
If current is 5 and total is 5, everything works correctly.
If current is 7 and total is 7, it shows 99% instead of 100% as float value is not 100 because divide is incorrect.

This PR fixes this issue.